### PR TITLE
updates for Tower 3.0.3

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,8 +4,7 @@
 Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox"
   config.vm.provider "vmware_fusion"
-  config.vm.box = "Opscode centos-6.5"
-  config.vm.box_url = "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box"
+  config.vm.box = "centos/7"
   config.vm.box_check_update = true
   config.ssh.forward_agent = false
   config.ssh.insert_key = false
@@ -75,5 +74,3 @@ Vagrant.configure("2") do |config|
   end
 
 end
-
-

--- a/group_vars/all
+++ b/group_vars/all
@@ -13,10 +13,10 @@ tower_host: tower
 rh: el{{ ansible_distribution_major_version }}
 rel: rhel{{ ansible_distribution_major_version }}
 
-tower_version: 3.0.2-1
+tower_version: 3.0.3-1
 tower_name: ansible-tower-setup-bundle-{{ tower_version }}.{{ rh }}
 tower_url: https://releases.ansible.com/ansible-tower/setup-bundle/{{ tower_name }}.tar.gz
-ansible_rpm: "{{ temp_dir }}/{{ tower_name }}/bundle/repos/epel/ansible-2.1.1.0-1.{{ rh }}.noarch.rpm"
+ansible_rpm: "{{ temp_dir }}/{{ tower_name }}/bundle/repos/epel/ansible-2.1.2.0-1.{{ rh }}.noarch.rpm"
 pg_rpm_dir: '{{ temp_dir }}/{{ tower_name }}/bundle/repos/pgdg94'
 
 # don't change these

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
 
 postgres_packages:
-  - "{{pg_rpm_dir}}/postgresql94-libs-9.4.9-1PGDG.rhel{{ ansible_distribution_major_version }}.x86_64.rpm"
-  - "{{pg_rpm_dir}}/postgresql94-9.4.9-1PGDG.rhel{{ ansible_distribution_major_version }}.x86_64.rpm"
-  - "{{pg_rpm_dir}}/postgresql94-server-9.4.9-1PGDG.rhel{{ ansible_distribution_major_version }}.x86_64.rpm"
-  - "{{pg_rpm_dir}}/python-psycopg2-2.6.2-1.rhel{{ ansible_distribution_major_version }}.x86_64.rpm"
+  - "{{pg_rpm_dir}}/postgresql94-libs-9.4.10-1PGDG.rhel{{ ansible_distribution_major_version }}.x86_64.rpm"
+  - "{{pg_rpm_dir}}/postgresql94-9.4.10-1PGDG.rhel{{ ansible_distribution_major_version }}.x86_64.rpm"
+  - "{{pg_rpm_dir}}/postgresql94-server-9.4.10-1PGDG.rhel{{ ansible_distribution_major_version }}.x86_64.rpm"
+  - "{{pg_rpm_dir}}/python-psycopg2-2.6.2-3.rhel{{ ansible_distribution_major_version }}.x86_64.rpm"
 
 postgres_jdbc_url: "https://jdbc.postgresql.org/download/postgresql-9.4-1201.jdbc41.jar"

--- a/roles/tower/defaults/main.yml
+++ b/roles/tower/defaults/main.yml
@@ -1,4 +1,4 @@
-tower_version: 3.0.2-1
+tower_version: 3.0.3-1
 
 tower_name: ansible-tower-setup-bundle-{{ tower_version }}.el{{ ansible_distribution_major_version }}
 tower_url: https://releases.ansible.com/ansible-tower/setup-bundle/{{ tower_name }}.tar.gz
@@ -13,9 +13,9 @@ tower_ldap_base_dn: "O=Ansible"
 tower_ldap_user_base: "OU=Group,OU=Organization,O=Ansible"
 
 python_libs:
-  - "{{pg_rpm_dir}}/postgresql94-libs-9.4.9-1PGDG.rhel{{ ansible_distribution_major_version }}.x86_64.rpm"
-  - "{{pg_rpm_dir}}/python-psycopg2-2.6.2-1.rhel{{ ansible_distribution_major_version }}.x86_64.rpm"
-  - "{{pg_rpm_dir}}/postgresql94-9.4.9-1PGDG.rhel{{ ansible_distribution_major_version }}.x86_64.rpm"
+  - "{{pg_rpm_dir}}/postgresql94-libs-9.4.10-1PGDG.rhel{{ ansible_distribution_major_version }}.x86_64.rpm"
+  - "{{pg_rpm_dir}}/python-psycopg2-2.6.2-3.rhel{{ ansible_distribution_major_version }}.x86_64.rpm"
+  - "{{pg_rpm_dir}}/postgresql94-9.4.10-1PGDG.rhel{{ ansible_distribution_major_version }}.x86_64.rpm"
 
 python_pips:
   - pbr>=1.8


### PR DESCRIPTION
- Updates to install the freshly released 3.0.3
- Changed Vagrantbox to Official Centos 7 box. Python 2.6 was used in other one. Python 2.7 is desirable, and support for 2.6 deprecated, as warned by Ansible.

Tested on Vagrant/single_node.