### PR TITLE
Monitoring - Logstash shipper role added

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -23,3 +23,4 @@
     - git
     - tower
     - towercli
+    - logstash_shipper

--- a/roles/logstash_shipper/defaults/main.yml
+++ b/roles/logstash_shipper/defaults/main.yml
@@ -1,0 +1,38 @@
+---
+#Variables for your host config of logstash
+logstash_user: logstash
+grok_pattern_path: "/etc/logstash/patterns"
+logstash_ansible_tower_config_path: "/etc/logstash/conf.d"
+
+#List of log file paths and names to be configured as a part of the logstash template    
+logs:
+  - { path: "/var/log/tower/" , filename: "tower.log" }
+  - { path: "/var/log/tower/" , filename: "task_system.log" }
+  - { path: "/var/log/tower/" , filename: "socketio_service.log" }
+  - { path: "/var/log/tower/" , filename: "fact_receiver.log" }
+  - { path: "/var/log/tower/" , filename: "callback_receiver.log" }
+  - { path: "/var/log/supervisor/" , filename: "awx-celery.log" }
+  - { path: "/var/log/supervisor/" , filename: "supervisord.log" }
+
+# Tag name for identifying logging by tags and defining their logging properties
+type_tag: "ansible-tower"
+
+# Local path for finding patterns for log shipping
+patterns_path: "./pattern"    
+
+#Log properties for the tags
+log_domain_name: "ANSIBLE-TOWER-DOMAIN-NAME" #To be changed as per your naming convention
+log_type: "application"
+log_component: "ANSIBLE-TOWER-ALL-LOGS"
+config_item: "ANSIBLE-TOWER"
+event_type: "TECHNICAL"
+
+#Output config
+redis_host: "logging.com" #To be changed as per requirement
+output_data_type: "list"
+output_key: "logstash"
+output_codec: "json"
+
+#Note that the file path should exist before you configure the same below
+file_output: "/var/log/logadapter/temporary.test" #Only a temporary test location to test output patterns based on template"
+std_output: "rubydebug"

--- a/roles/logstash_shipper/files/grok-patterns
+++ b/roles/logstash_shipper/files/grok-patterns
@@ -1,0 +1,94 @@
+USERNAME [a-zA-Z0-9._-]+
+USER %{USERNAME}
+INT (?:[+-]?(?:[0-9]+))
+BASE10NUM (?<![0-9.+-])(?>[+-]?(?:(?:[0-9]+(?:\.[0-9]+)?)|(?:\.[0-9]+)))
+NUMBER (?:%{BASE10NUM})
+BASE16NUM (?<![0-9A-Fa-f])(?:[+-]?(?:0x)?(?:[0-9A-Fa-f]+))
+BASE16FLOAT \b(?<![0-9A-Fa-f.])(?:[+-]?(?:0x)?(?:(?:[0-9A-Fa-f]+(?:\.[0-9A-Fa-f]*)?)|(?:\.[0-9A-Fa-f]+)))\b
+
+POSINT \b(?:[1-9][0-9]*)\b
+NONNEGINT \b(?:[0-9]+)\b
+WORD \b\w+\b
+NOTSPACE \S+
+SPACE \s*
+DATA .*?
+GREEDYDATA .*
+QUOTEDSTRING (?>(?<!\\)(?>"(?>\\.|[^\\"]+)+"|""|(?>'(?>\\.|[^\\']+)+')|''|(?>`(?>\\.|[^\\`]+)+`)|``))
+UUID [A-Fa-f0-9]{8}-(?:[A-Fa-f0-9]{4}-){3}[A-Fa-f0-9]{12}
+
+# Networking
+MAC (?:%{CISCOMAC}|%{WINDOWSMAC}|%{COMMONMAC})
+CISCOMAC (?:(?:[A-Fa-f0-9]{4}\.){2}[A-Fa-f0-9]{4})
+WINDOWSMAC (?:(?:[A-Fa-f0-9]{2}-){5}[A-Fa-f0-9]{2})
+COMMONMAC (?:(?:[A-Fa-f0-9]{2}:){5}[A-Fa-f0-9]{2})
+IPV6 ((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?
+IPV4 (?<![0-9])(?:(?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[.](?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[.](?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[.](?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2}))(?![0-9])
+IP (?:%{IPV6}|%{IPV4})
+HOSTNAME \b(?:[0-9A-Za-z][0-9A-Za-z-]{0,62})(?:\.(?:[0-9A-Za-z][0-9A-Za-z-]{0,62}))*(\.?|\b)
+HOST %{HOSTNAME}
+IPORHOST (?:%{HOSTNAME}|%{IP})
+HOSTPORT %{IPORHOST}:%{POSINT}
+
+# paths
+PATH (?:%{UNIXPATH}|%{WINPATH})
+UNIXPATH (?>/(?>[\w_%!$@:.,-]+|\\.)*)+
+TTY (?:/dev/(pts|tty([pq])?)(\w+)?/?(?:[0-9]+))
+WINPATH (?>[A-Za-z]+:|\\)(?:\\[^\\?*]*)+
+URIPROTO [A-Za-z]+(\+[A-Za-z+]+)?
+URIHOST %{IPORHOST}(?::%{POSINT:port})?
+# uripath comes loosely from RFC1738, but mostly from what Firefox
+# doesn't turn into %XX
+URIPATH (?:/[A-Za-z0-9$.+!*'(){},~:;=@#%_\-]*)+
+#URIPARAM \?(?:[A-Za-z0-9]+(?:=(?:[^&]*))?(?:&(?:[A-Za-z0-9]+(?:=(?:[^&]*))?)?)*)?
+URIPARAM \?[A-Za-z0-9$.+!*'|(){},~@#%&/=:;_?\-\[\]]*
+URIPATHPARAM %{URIPATH}(?:%{URIPARAM})?
+URI %{URIPROTO}://(?:%{USER}(?::[^@]*)?@)?(?:%{URIHOST})?(?:%{URIPATHPARAM})?
+
+# Months: January, Feb, 3, 03, 12, December
+MONTH \b(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\b
+MONTHNUM (?:0?[1-9]|1[0-2])
+MONTHNUM2 (?:0[1-9]|1[0-2])
+MONTHDAY (?:(?:0[1-9])|(?:[12][0-9])|(?:3[01])|[1-9])
+
+# Days: Monday, Tue, Thu, etc...
+DAY (?:Mon(?:day)?|Tue(?:sday)?|Wed(?:nesday)?|Thu(?:rsday)?|Fri(?:day)?|Sat(?:urday)?|Sun(?:day)?)
+
+# Years?
+YEAR (?>\d\d){1,2}
+HOUR (?:2[0123]|[01]?[0-9])
+MINUTE (?:[0-5][0-9])
+# '60' is a leap second in most time standards and thus is valid.
+SECOND (?:(?:[0-5]?[0-9]|60)(?:[:.,][0-9]+)?)
+TIME (?!<[0-9])%{HOUR}:%{MINUTE}(?::%{SECOND})(?![0-9])
+# datestamp is YYYY/MM/DD-HH:MM:SS.UUUU (or something like it)
+DATE_US %{MONTHNUM}[/-]%{MONTHDAY}[/-]%{YEAR}
+DATE_EU %{MONTHDAY}[./-]%{MONTHNUM}[./-]%{YEAR}
+ISO8601_TIMEZONE (?:Z|[+-]%{HOUR}(?::?%{MINUTE}))
+ISO8601_SECOND (?:%{SECOND}|60)
+TIMESTAMP_ISO8601 %{YEAR}-%{MONTHNUM}-%{MONTHDAY}[T ]%{HOUR}:?%{MINUTE}(?::?%{SECOND})?%{ISO8601_TIMEZONE}?
+DATE %{DATE_US}|%{DATE_EU}
+DATESTAMP %{DATE}[- ]%{TIME}
+TZ (?:[PMCE][SD]T|UTC)
+DATESTAMP_RFC822 %{DAY} %{MONTH} %{MONTHDAY} %{YEAR} %{TIME} %{TZ}
+DATESTAMP_RFC2822 %{DAY}, %{MONTHDAY} %{MONTH} %{YEAR} %{TIME} %{ISO8601_TIMEZONE}
+DATESTAMP_OTHER %{DAY} %{MONTH} %{MONTHDAY} %{TIME} %{TZ} %{YEAR}
+DATESTAMP_EVENTLOG %{YEAR}%{MONTHNUM2}%{MONTHDAY}%{HOUR}%{MINUTE}%{SECOND}
+
+# Syslog Dates: Month Day HH:MM:SS
+SYSLOGTIMESTAMP %{MONTH} +%{MONTHDAY} %{TIME}
+PROG (?:[\w._/%-]+)
+SYSLOGPROG %{PROG:program}(?:\[%{POSINT:pid}\])?
+SYSLOGHOST %{IPORHOST}
+SYSLOGFACILITY <%{NONNEGINT:facility}.%{NONNEGINT:priority}>
+HTTPDATE %{MONTHDAY}/%{MONTH}/%{YEAR}:%{TIME} %{INT}
+
+# Shortcuts
+QS %{QUOTEDSTRING}
+
+# Log formats
+SYSLOGBASE %{SYSLOGTIMESTAMP:timestamp} (?:%{SYSLOGFACILITY} )?%{SYSLOGHOST:logsource} %{SYSLOGPROG}:
+COMMONAPACHELOG %{IPORHOST:clientip} %{USER:ident} %{USER:auth} \[%{HTTPDATE:timestamp}\] "(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})" %{NUMBER:response} (?:%{NUMBER:bytes}|-)
+COMBINEDAPACHELOG %{COMMONAPACHELOG} %{QS:referrer} %{QS:agent}
+
+# Log Levels
+LOGLEVEL ([A|a]lert|ALERT|[T|t]race|TRACE|[D|d]ebug|DEBUG|[N|n]otice|NOTICE|[I|i]nfo|INFO|[W|w]arn?(?:ing)?|WARN?(?:ING)?|[E|e]rr?(?:or)?|ERR?(?:OR)?|[C|c]rit?(?:ical)?|CRIT?(?:ICAL)?|[F|f]atal|FATAL|[S|s]evere|SEVERE|EMERG(?:ENCY)?|[Ee]merg(?:ency)?)

--- a/roles/logstash_shipper/handlers/main.yml
+++ b/roles/logstash_shipper/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart logstash
+  service: name=logstash state=restarted
+  become: true
+  become_user: "{{ logstash_user }}"

--- a/roles/logstash_shipper/tasks/main.yml
+++ b/roles/logstash_shipper/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- assert:
+    that:
+      - "dtap_stage is defined"
+    msg: "Please pass a value for variable. Example: Dev, Test, Production etc"
+  tags:
+    - logstash
+        
+- name: Copy grok pattern file
+  copy:
+    src=grok-patterns
+    dest={{ grok_pattern_path }}/grok-patterns
+  become: true
+  become_user: "{{ logstash_user }}"
+  tags:
+    - config
+    - logstash
+
+- name: Copy template
+  template:
+    src=ansible_tower_logstash_shipper.conf.j2
+    dest={{ logstash_ansible_tower_config_path }}/ansible-tower.conf  
+  become: true
+  become_user: "{{ logstash_user }}"
+  tags:
+    - config
+    - logstash
+  notify:
+    - restart logstash

--- a/roles/logstash_shipper/templates/ansible_tower_logstash_shipper.conf.j2
+++ b/roles/logstash_shipper/templates/ansible_tower_logstash_shipper.conf.j2
@@ -1,0 +1,60 @@
+input {
+{% for item in logs %}
+            file  {
+                path => {{ item.path }}_{{ item.filename }}
+                type => "{{ type_tag }}"
+                start_position => "beginning"
+                 }
+{% endfor %}
+     }
+
+filter {
+
+  if [type] == "{{ type_tag }}" {
+    multiline {
+         pattern => "^\s"
+                 what => "previous"
+    }
+
+     grok {
+     patterns_dir => "{{ patterns_path }}"
+          match => {
+          "message" => [ "%{TIMESTAMP_ISO8601:timestamp} %{WORD:severity} %{GREEDYDATA:msg} " ]
+}
+}
+
+         mutate{
+             add_tag => ["{{ type_tag|upper }}"]
+
+             add_field => {
+                "log_domain" => "{{ log_domain_name }}"
+                "log_type" => "{{ log_type }}"
+                "log_component" => "{{ log_component }}"
+                "DTAP_Stage" => "{{ dtap_stage }}"
+                "ci" => "{{ config_item }}"
+                "Event Type" => "{{ event_type }}"
+                        }
+                }
+               }
+}
+
+output {
+
+redis {
+host => "{{ redis_host }}"
+data_type => "{{ output_data_type }}"
+key => "{{ output_key }}"
+codec => {{ output_codec }}
+}
+
+
+#file {
+#       codec => {{ output_codec }}
+#Note that the file path should exist before you configure the same below
+#       path => ["{{ file_output  }}"]
+#
+#
+#}
+
+stdout { codec => {{ std_output }} }
+}


### PR DESCRIPTION
Ansible Tower App Server can be monitored using various monitoring tools like Logstash, Splunk etc.

Adding a logstash_shipper role that will ship parsed logs from 7 default log files of Ansible Tower App Server to central logging and monitoring.